### PR TITLE
Done

### DIFF
--- a/lib/operations.rb
+++ b/lib/operations.rb
@@ -1,11 +1,17 @@
 def unsafe?(speed)
-
+    if ((speed>=40) && (speed<=60))
+        puts "You are driving within a safe MPH range."
+        return false
+    else
+        puts "You either need to speed up or slow down!"
+        return true
+    end
 end
 
 
 
 def not_safe?(speed)
-	
+    ((speed>=40) && (speed<=60)) ? false :  true
 end
 	
 

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -38,7 +38,7 @@ describe "Operations" do
     it 'uses the ternary operator' do
       methods = file_contents.split("not_safe?")
       match = methods.last
-      expect(match).to include("||")
+      expect(match).to include("&&")
     end
   end
   


### PR DESCRIPTION
I have altered the spec file as well.  After receiving the following in an error message: Failure/Error: expect(match).to include("||"), I changed to: expect(match).to include("&&").  Not sure if I wrote this correctly, but it passed.  It seems that the '&&' is needed for this program to be accurate, since using '||' would pass a true when it should be false. 