### PR TITLE
Updated README, Statement Modifiers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ However, we don't want to say "Hey, it's 2015!" every time this code is run. We 
 
 ```ruby
 this_year = Time.now.year
-puts "Hey, it's 2015!" if this_year == "2015"
+puts "Hey, it's 2015!" if this_year == 2015
 ``` 
-Now, with the statement modifier `if this_year == "2015"` we are only putting it if the year is, in fact, 2015.
+Now, with the statement modifier `if this_year == 2015` we are only putting it if the year is, in fact, 2015.
 
 We can also use `unless` in a statement modifier as well. 
 
 ```ruby
 this_year = Time.now.year
-puts "Hey, it's not 2015!" unless this_year == "2015"
+puts "Hey, it's not 2015!" unless this_year == 2015
 ``` 
 
 

--- a/lib/operations.rb
+++ b/lib/operations.rb
@@ -1,11 +1,14 @@
 def unsafe?(speed)
-
+  if speed > 60 || speed < 40
+    true
+  else
+    false
+  end
 end
 
-
-
 def not_safe?(speed)
-	
+  #between? is inclusive
+  speed.between?(40, 60) ? false : true	
 end
 	
 


### PR DESCRIPTION
Proposing to remove quotes around 2015 in the Statement Modifiers examples because `Time.now.year` is class Fixnum, not String.  Therefore, `this_year == "2015"` will always be false.  I believe it should be `this_year == 2015`.
